### PR TITLE
🐛 starshipのPythonバージョン表示を修正

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -30,8 +30,7 @@ mantle    = "#181825"
 crust     = "#11111b"
 
 [python]
-python_binary      = ['python3', 'python', 'python2']
-pyenv_version_name = true
+python_binary = ['python3', 'python', 'python2']
 
 [time]
 disabled    = false


### PR DESCRIPTION
## Summary
- pyenv未使用環境で`pyenv_version_name = true`が設定されていたため、Pythonバージョンが表示されない問題を修正
- miseでPythonを管理しているため、`python3 --version`で直接バージョンを取得するように変更