### PR TITLE
🔧 Rancher Desktopのソケット存在時にDOCKER_HOSTを設定

### DIFF
--- a/zshrc.d/docker.zsh
+++ b/zshrc.d/docker.zsh
@@ -1,5 +1,9 @@
 export DOCKER_CONFIG="$HOME/.config/docker"
 
+if [[ -S "$HOME/.rd/docker.sock" ]]; then
+  export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+fi
+
 if builtin command -v docker > /dev/null 2>&1; then
 
   function exec_docker_command() {


### PR DESCRIPTION
## Summary
- `$HOME/.rd/docker.sock` が存在する場合に `DOCKER_HOST` を設定するように `zshrc.d/docker.zsh` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)