### PR TITLE
✨ Kotlin/Java/Quarkus開発環境を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh pr merge:*)"
-    ]
-  }
-}

--- a/.gitconfig
+++ b/.gitconfig
@@ -57,9 +57,9 @@
   email = miya10kei@gmail.com
   name = miya10kei
 [credential "https://github.com"]
-  helper = !/root/.local/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
-  helper = !/root/.local/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [coderabbit]
   machineId = cli/0b574cd1beaa428e963b5cdd1b4b76c7
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -260,11 +260,11 @@
     "lua-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "typescript-lsp@nealle-managed": true
   },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -2,25 +2,25 @@
 ASDF_LUA_LUAROCKS_VERSION = "3.12.2"
 
 [plugins]
-lua             = "https://github.com/mise-plugins/mise-lua.git"
-ghc             = "https://github.com/sestrella/asdf-ghcup.git"
-cabal           = "https://github.com/sestrella/asdf-ghcup.git"
-stack           = "https://github.com/sestrella/asdf-ghcup.git"
-terraform       = "https://github.com/mise-plugins/mise-hashicorp.git"
-gcloud          = "https://github.com/mise-plugins/mise-gcloud.git"
-"1password-cli" = "https://github.com/NeoHsu/asdf-1password-cli.git"
+lua       = "https://github.com/mise-plugins/mise-lua.git"
+ghc       = "https://github.com/sestrella/asdf-ghcup.git"
+cabal     = "https://github.com/sestrella/asdf-ghcup.git"
+stack     = "https://github.com/sestrella/asdf-ghcup.git"
+terraform = "https://github.com/mise-plugins/mise-hashicorp.git"
 
 [tools]
 # Language runtimes
 bun         = "latest"
 deno        = "latest"
 go          = "latest"
+java        = "25"
+kotlin      = "latest"
 lua         = "5.4.7"
 neovim      = "latest"
 node        = "22"
 python      = ["3.14", "3.13", "3.11"]
+quarkus     = "latest"
 rust        = "latest"
-gcloud      = "latest"
 terraform   = "latest"
 tree-sitter = "latest"
 
@@ -29,10 +29,8 @@ cabal = "latest"
 ghc   = "latest"
 stack = "latest"
 
-# asdf plugins
-"1password-cli" = "latest"
-
 # aqua packages
+"aqua:1password/cli"          = "latest"
 "aqua:ajeetdsouza/zoxide"     = "latest"
 "aqua:astral-sh/uv"           = "latest"
 "aqua:aws/aws-cli"            = "latest"
@@ -78,7 +76,11 @@ stack = "latest"
 # pipx packages
 "pipx:aws-sam-cli"     = "latest"
 "pipx:git-filter-repo" = "latest"
+"pipx:markitdown"      = { version = "latest", extras = "all" }
 "pipx:pgcli"           = "latest"
+
+# vfox packages
+"vfox:gcloud" = "latest"
 
 # http downloads
 "http:fzf-completion"      = { version = "latest", url = "https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh" }
@@ -87,8 +89,11 @@ stack = "latest"
 "github:miya10kei/ccargus" = "latest"
 "github:miya10kei/ccjanus" = "latest"
 
+# cargo packages
+"cargo:kotlin-lsp" = "latest"
+
 [settings]
-experimental           = false
+experimental           = true
 idiomatic_version_file = true
 not_found_auto_install = true
 trusted_config_paths   = ["~/dev"]
@@ -108,3 +113,7 @@ run         = "curl -fsSL https://claude.ai/install.sh | bash"
 [tasks.install-coderabbit]
 description = "Install CodeRabbit CLI"
 run         = "curl -fsSL https://cli.coderabbit.ai/install.sh | sh"
+
+[tasks."kotlin-lsp:extract-sources"]
+description = "kotlin-lspの依存ソースを~/.local/share/kotlin-lsp/sources/に抽出"
+run         = "python3 ~/.local/share/kotlin-lsp/extract-sources.py --output ~/.local/share/kotlin-lsp/sources"

--- a/config/nvim/lua/config/autocmd.lua
+++ b/config/nvim/lua/config/autocmd.lua
@@ -65,3 +65,17 @@ autocmd.create_group("GitHubActionsFiletype", {
     },
   },
 })
+
+-- LSPクライアントの強制停止（kotlin-lsp等のゾンビJVM対策）
+autocmd.create_group("LspForceStopOnExit", {
+  {
+    event = "VimLeavePre",
+    opts = {
+      callback = function()
+        for _, client in ipairs(vim.lsp.get_clients()) do
+          client:stop(true)
+        end
+      end,
+    },
+  },
+})

--- a/config/nvim/lua/plugins/lspconfig.lua
+++ b/config/nvim/lua/plugins/lspconfig.lua
@@ -7,6 +7,7 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
       "saghen/blink.cmp",
+      "folke/which-key.nvim",
       "williamboman/mason-lspconfig.nvim",
       "williamboman/mason.nvim",
     },
@@ -14,22 +15,76 @@ return {
       ---------------
       --- Keymaps ---
       ---------------
-      local keymap = vim.keymap.set
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("UserLspAttach", { clear = true }),
+        callback = function(args)
+          local bufnr = args.buf
+          require("which-key").add({
+            -- グループ
+            { "<Leader>l", group = "LSP", buffer = bufnr },
+            { "<Leader>ln", group = "Navigation", buffer = bufnr },
+            { "<Leader>lv", group = "View", buffer = bufnr },
+            { "<Leader>le", group = "Edit", buffer = bufnr },
+            -- ナビゲーション
+            { "<Leader>lnd", vim.lsp.buf.definition, desc = "Definition", buffer = bufnr, silent = true },
+            { "<Leader>lni", vim.lsp.buf.implementation, desc = "Implementation", buffer = bufnr, silent = true },
+            { "<Leader>lnt", vim.lsp.buf.type_definition, desc = "Type Definition", buffer = bufnr, silent = true },
+            { "<Leader>lnr", vim.lsp.buf.references, desc = "References", buffer = bufnr, silent = true },
+            { "<Leader>lns", vim.lsp.buf.incoming_calls, desc = "Incoming Calls", buffer = bufnr, silent = true },
+            { "<Leader>lno", vim.lsp.buf.outgoing_calls, desc = "Outgoing Calls", buffer = bufnr, silent = true },
+            -- 情報表示
+            { "<Leader>lvh", vim.lsp.buf.hover, desc = "Hover", buffer = bufnr, silent = true },
+            { "<Leader>lvs", vim.lsp.buf.signature_help, desc = "Signature Help", buffer = bufnr, silent = true },
+            { "<Leader>lve", vim.diagnostic.open_float, desc = "Diagnostic", buffer = bufnr, silent = true },
+            -- 編集
+            { "<Leader>ler", vim.lsp.buf.rename, desc = "Rename", buffer = bufnr, silent = true },
+            {
+              "<Leader>lea",
+              vim.lsp.buf.code_action,
+              desc = "Code Action",
+              buffer = bufnr,
+              silent = true,
+              mode = { "n", "v" },
+            },
+            {
+              "<Leader>lef",
+              function()
+                vim.lsp.buf.format({ async = true })
+              end,
+              desc = "Format",
+              buffer = bufnr,
+              silent = true,
+              mode = { "n", "v" },
+            },
+          })
 
-      local on_attach = function(_, bufnr)
-        local bufopts = { buffer = bufnr, silent = true }
-        keymap("n", "gD", vim.lsp.buf.declaration, bufopts)
-        keymap("n", "K", vim.lsp.buf.hover, bufopts)
-        keymap("n", "gi", vim.lsp.buf.implementation, bufopts)
-        keymap("n", "<Leader>wa", vim.lsp.buf.add_workspace_folder, bufopts)
-        keymap("n", "<Leader>wr", vim.lsp.buf.remove_workspace_folder, bufopts)
-        keymap("n", "<Leader>wl", function()
-          print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-        end, bufopts)
-        keymap("n", "<Leader>D", vim.lsp.buf.type_definition, bufopts)
-        keymap("n", "<Leader>rn", vim.lsp.buf.rename, bufopts)
-        keymap("n", "<Leader>ca", vim.lsp.buf.code_action, bufopts)
-      end
+          -- kotlin-lsp 専用：sourcePaths を再インデックス
+          local client = vim.lsp.get_client_by_id(args.data.client_id)
+          if client and client.name == "kotlin_lsp" then
+            require("which-key").add({
+              { "<Leader>ls", group = "Server", buffer = bufnr },
+              {
+                "<Leader>lsr",
+                function()
+                  client:exec_cmd({ command = "kotlin-lsp/reindex" })
+                end,
+                desc = "Reindex (kotlin-lsp)",
+                buffer = bufnr,
+                silent = true,
+              },
+              {
+                "<Leader>lsc",
+                function()
+                  client:exec_cmd({ command = "kotlin-lsp/clearCache" })
+                end,
+                desc = "Clear Cache (kotlin-lsp)",
+                buffer = bufnr,
+                silent = true,
+              },
+            })
+          end
+        end,
+      })
 
       require("mason-lspconfig").setup()
       local mason_registry = require("mason-registry")
@@ -63,7 +118,6 @@ return {
       -- グローバルLSP設定
       vim.lsp.config("*", {
         capabilities = capabilities,
-        on_attach = on_attach,
       })
 
       local used_mason_packages = {
@@ -196,6 +250,20 @@ return {
         end
         vim.lsp.enable(alias)
       end
+
+      -- Hessesian/kotlin-lsp（Rust製、mise の cargo:kotlin-lsp 経由）
+      -- 依存ライブラリのソースは `mise run kotlin-lsp:extract-sources` で抽出
+      vim.lsp.config("kotlin_lsp", {
+        cmd = { "kotlin-lsp" },
+        filetypes = { "kotlin" },
+        root_markers = { "settings.gradle.kts", "settings.gradle", "build.gradle.kts", "build.gradle", "pom.xml", ".git" },
+        init_options = {
+          indexingOptions = {
+            sourcePaths = { vim.fn.expand("~/.local/share/kotlin-lsp/sources") },
+          },
+        },
+      })
+      vim.lsp.enable("kotlin_lsp")
     end,
     keys = {
       {

--- a/config/nvim/lua/plugins/nvim-treesitter.lua
+++ b/config/nvim/lua/plugins/nvim-treesitter.lua
@@ -13,6 +13,7 @@ local parsers = {
   "java",
   "javascript",
   "json",
+  "kotlin",
   "lua",
   "make",
   "markdown",

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -11,6 +11,7 @@ set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-cpu'
+set -g @plugin 'sainnhe/tmux-fzf'
 
 if-shell "test -d #{@TMUX_HOME}/plugins/tpm && test ! -d #{@TMUX_HOME}/plugins/tmux" \
    "run-shell '#{@TMUX_HOME}/plugins/tpm/bin/install_plugins'"


### PR DESCRIPTION
## Summary
- mise に Java(25)/Kotlin/Quarkus と cargo:kotlin-lsp を追加し、Kotlin/JVM 開発環境を整備
- Neovim に kotlin-lsp 設定・Kotlin treesitter・LSP キーマップの which-key 化を導入
- gcloud→vfox / 1password-cli→aqua へバックエンド移行、tmux-fzf 追加など周辺設定を整理

## Test plan
- [ ] `mise install` で Java/Kotlin/Quarkus/kotlin-lsp が導入できること
- [ ] Neovim で .kt ファイルを開いて kotlin-lsp が attach し、definition/hover/code action が動作すること
- [ ] `<Leader>l` で which-key メニューが表示されること
- [ ] Neovim 終了時に kotlin-lsp の JVM プロセスが残らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)