### PR TITLE
🔧 Claude Codeとmiseの設定を更新

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -268,5 +268,6 @@
   },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
-  "showTurnDuration": true
+  "showTurnDuration": true,
+  "skipAutoPermissionPrompt": true
 }

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -93,10 +93,10 @@ stack = "latest"
 "cargo:kotlin-lsp" = "latest"
 
 [settings]
-experimental           = true
-idiomatic_version_file = true
-not_found_auto_install = true
-trusted_config_paths   = ["~/dev"]
+experimental                        = true
+idiomatic_version_file_enable_tools = ["terraform"]
+not_found_auto_install              = true
+trusted_config_paths                = ["~/dev"]
 
 [tasks.install-bins]
 depends     = ["install-claude-code", "install-coderabbit", "install-gh-extensions", "install-session-manager"]


### PR DESCRIPTION
## Summary
- Claude Codeに `skipAutoPermissionPrompt: true` を追加し自動権限プロンプトをスキップ
- miseの `idiomatic_version_file` を `idiomatic_version_file_enable_tools = ["terraform"]` に変更してterraformのみ有効化