### PR TITLE
✨ herdr の設定管理を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ setup4d: \
 	deploy-git \
 	deploy-gpg \
 	deploy-gws \
+	deploy-herdr \
 	deploy-markdownlint \
 	deploy-mise \
 	deploy-npm \

--- a/Makefile.d/deploy.mk
+++ b/Makefile.d/deploy.mk
@@ -101,6 +101,16 @@ $(HOME)/.config/gws:
 
 
 # ----------------------------------------------------------------------------------------------------------------------
+.PHONY: deploy-herdr
+deploy-herdr: \
+	$(HOME)/.config/herdr/config.toml
+
+$(HOME)/.config/herdr/config.toml:
+	mkdir -p $(HOME)/.config/herdr
+	ln -fns $(DOTDIR)/config/herdr/config.toml $(HOME)/.config/herdr/config.toml
+
+
+# ----------------------------------------------------------------------------------------------------------------------
 .PHONY: deploy-gpg
 deploy-gpg: \
 	$(HOME)/.gnupg

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -1,0 +1,21 @@
+[keys]
+prefix = "ctrl+g"
+split_vertical = "prefix+|"
+navigate_workspace_up = "k"
+navigate_workspace_down = "j"
+previous_agent = "prefix+,"
+next_agent = "prefix+."
+
+[[keys.command]]
+key = "prefix+u"
+type = "popup"
+command = "~/.dotfiles/config/herdr/scripts/new-worktree.sh"
+width = "50%"
+height = "60%"
+
+[ui]
+sidebar_width = 36
+
+[experimental]
+pane_history = true
+switch_ascii_input_source_in_prefix = true

--- a/config/herdr/scripts/new-worktree.sh
+++ b/config/herdr/scripts/new-worktree.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_short=$(ghq list | fzf --prompt="repo> ")
+[ -z "$repo_short" ] && exit 0
+repo="$(ghq root)/$repo_short"
+
+read -rp "worktree branch name: " branch
+[ -z "$branch" ] && exit 0
+
+herdr worktree create --cwd "$repo" --branch "$branch" --focus


### PR DESCRIPTION
## Summary
- herdrのconfig.tomlをdotfilesで管理下に置く（`~/.config/herdr/config.toml`をシンボリックリンク化）
- prefixキーを`ctrl+g`に変更、垂直分割・agent移動・workspace navigateのキーバインドを追加
- ghq+fzfでリポジトリ選択→worktree作成するカスタムコマンド（`prefix+u`）を追加
- `Makefile.d/deploy.mk`に`deploy-herdr`ターゲットを追加し、`setup4d`に組み込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)