### PR TITLE
✨ prefix+u のリポジトリ候補にdotfilesを追加

### DIFF
--- a/config/herdr/scripts/new-worktree.sh
+++ b/config/herdr/scripts/new-worktree.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_short=$(ghq list | fzf --prompt="repo> ")
+repo_short=$({ echo "dotfiles"; ghq list; } | fzf --prompt="repo> ")
 [ -z "$repo_short" ] && exit 0
-repo="$(ghq root)/$repo_short"
+if [ "$repo_short" = "dotfiles" ]; then
+  repo="$HOME/.dotfiles"
+else
+  repo="$(ghq root)/$repo_short"
+fi
 
 read -rp "worktree branch name: " branch
 [ -z "$branch" ] && exit 0


### PR DESCRIPTION
## Summary
- `new-worktree.sh`のfzf候補先頭に`dotfiles`（ghq管理外、`~/.dotfiles`）を追加
- dotfiles自体もherdrのworktreeフローで作業できるように

🤖 Generated with [Claude Code](https://claude.com/claude-code)