### PR TITLE
✨ workspace切替・pane移動にprefix不要のショートカットを追加

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -6,6 +6,12 @@ navigate_workspace_up = "k"
 navigate_workspace_down = "j"
 previous_agent = "prefix+,"
 next_agent = "prefix+."
+previous_workspace = "ctrl+alt+p"
+next_workspace = "ctrl+alt+n"
+focus_pane_left = "ctrl+alt+h"
+focus_pane_down = "ctrl+alt+j"
+focus_pane_up = "ctrl+alt+k"
+focus_pane_right = "ctrl+alt+l"
 
 [[keys.command]]
 key = "prefix+u"


### PR DESCRIPTION
## Summary
- `previous_workspace`/`next_workspace`を`ctrl+alt+p`/`ctrl+alt+n`に割当（prefix不要）
- `focus_pane_left/down/up/right`を`ctrl+alt+h/j/k/l`に割当（prefix不要）
- prefix連打の手間を減らし、頻用操作を直接ショートカット化

🤖 Generated with [Claude Code](https://claude.com/claude-code)