### PR TITLE
✨ herdrにファイルパス挿入popupを追加しscripts参照をXDG設定配下に統一

### DIFF
--- a/Makefile.d/deploy.mk
+++ b/Makefile.d/deploy.mk
@@ -103,11 +103,16 @@ $(HOME)/.config/gws:
 # ----------------------------------------------------------------------------------------------------------------------
 .PHONY: deploy-herdr
 deploy-herdr: \
-	$(HOME)/.config/herdr/config.toml
+	$(HOME)/.config/herdr/config.toml \
+	$(HOME)/.config/herdr/scripts
 
 $(HOME)/.config/herdr/config.toml:
 	mkdir -p $(HOME)/.config/herdr
 	ln -fns $(DOTDIR)/config/herdr/config.toml $(HOME)/.config/herdr/config.toml
+
+$(HOME)/.config/herdr/scripts:
+	mkdir -p $(HOME)/.config/herdr
+	ln -fns $(DOTDIR)/config/herdr/scripts $(HOME)/.config/herdr/scripts
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/config/claude/hooks/herdr-agent-state.sh
+++ b/config/claude/hooks/herdr-agent-state.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=claude
+# HERDR_INTEGRATION_VERSION=7
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-claude-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:claude"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+is_subagent = bool(hook_input.get("agent_id"))
+if is_subagent:
+    raise SystemExit(0)
+if hook_event_name == "SubagentStop":
+    # SubagentStop is a completion event. Older Herdr integrations mapped it
+    # to durable working, but Claude recap/away-summary can emit it after the
+    # main turn has already stopped. Never let it revive an idle pane.
+    raise SystemExit(0)
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+transcript_path = hook_input.get("transcript_path")
+agent_session_path = transcript_path if isinstance(transcript_path, str) and transcript_path else None
+session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+if not isinstance(session_start_source, str) or not session_start_source:
+    session_start_source = None
+if agent_session_id:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "claude",
+        "seq": report_seq,
+        "agent_session_id": agent_session_id,
+    }
+    if agent_session_path:
+        params["agent_session_path"] = agent_session_path
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "advisorModel": "fable",
+  "agentPushNotifEnabled": true,
+  "alwaysThinkingEnabled": true,
+  "autoMemoryEnabled": false,
   "cleanupPeriodDays": 14,
+  "companyAnnouncements": [
+    "個人契約のClaude Codeです"
+  ],
+  "disableClaudeAiConnectors": true,
+  "editorMode": "normal",
+  "effort": "high",
+  "enabledPlugins": {
+    "aws-knowledge@nealle-managed": true,
+    "datadog@nealle-managed": true,
+    "typescript-lsp@nealle-managed": true
+  },
   "env": {
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-fable-5[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5[1m]",
@@ -9,7 +24,42 @@
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "ccjanus --flexible-match",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bash '$CLAUDE_CONFIG_DIR/hooks/herdr-agent-state.sh' session",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ]
+  },
   "includeCoAuthoredBy": true,
+  "language": "Japanese",
   "permissions": {
     "allow": [
       "Bash(./gradlew *)",
@@ -158,6 +208,7 @@
       "mcp__plugin_atlassian_atlassian__search*",
       "mcp__plugin_context7_context7__*"
     ],
+    "defaultMode": "plan",
     "deny": [
       "Bash(docker buildx build * --push)",
       "Bash(docker buildx build * --push *)",
@@ -208,54 +259,15 @@
       "Bash(git push origin -f)",
       "Bash(terraform apply *)",
       "Bash(terraform apply)"
-    ],
-    "defaultMode": "plan"
-  },
-  "disableClaudeAiConnectors": true,
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "ccjanus --flexible-match"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh"
-          }
-        ]
-      }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "npx -y ccstatusline@latest",
-    "padding": 0
-  },
-  "enabledPlugins": {
-    "typescript-lsp@nealle-managed": true,
-    "datadog@nealle-managed": true,
-    "aws-knowledge@nealle-managed": true
-  },
-  "language": "Japanese",
-  "alwaysThinkingEnabled": true,
-  "advisorModel": "fable",
-  "companyAnnouncements": [
-    "個人契約のClaude Codeです"
-  ],
-  "tui": "fullscreen",
-  "autoMemoryEnabled": false,
-  "skipWorkflowUsageWarning": true,
-  "editorMode": "normal",
   "showTurnDuration": true,
-  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "effort": "high"
+  "skipWorkflowUsageWarning": true,
+  "statusLine": {
+    "command": "npx -y ccstatusline@latest",
+    "padding": 0,
+    "type": "command"
+  },
+  "tui": "fullscreen"
 }

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -6,12 +6,12 @@ navigate_workspace_up = "k"
 navigate_workspace_down = "j"
 previous_agent = "prefix+,"
 next_agent = "prefix+."
-previous_workspace = "ctrl+alt+p"
-next_workspace = "ctrl+alt+n"
-focus_pane_left = "ctrl+alt+h"
-focus_pane_down = "ctrl+alt+j"
-focus_pane_up = "ctrl+alt+k"
-focus_pane_right = "ctrl+alt+l"
+previous_workspace = "ctrl+shift+p"
+next_workspace = "ctrl+shift+n"
+focus_pane_left = "ctrl+shift+h"
+focus_pane_down = "ctrl+shift+j"
+focus_pane_up = "ctrl+shift+k"
+focus_pane_right = "ctrl+shift+l"
 
 [[keys.command]]
 key = "prefix+u"
@@ -33,3 +33,6 @@ sidebar_width = 36
 [experimental]
 pane_history = true
 switch_ascii_input_source_in_prefix = true
+
+[update]
+channel = "stable"

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -16,9 +16,16 @@ focus_pane_right = "ctrl+alt+l"
 [[keys.command]]
 key = "prefix+u"
 type = "popup"
-command = "~/.dotfiles/config/herdr/scripts/new-worktree.sh"
+command = "~/.config/herdr/scripts/new-worktree.sh"
 width = "50%"
 height = "40%"
+
+[[keys.command]]
+key = "prefix+f"
+type = "popup"
+command = "~/.config/herdr/scripts/insert-file-path.sh"
+width = "60%"
+height = "60%"
 
 [ui]
 sidebar_width = 36

--- a/config/herdr/scripts/insert-file-path.sh
+++ b/config/herdr/scripts/insert-file-path.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+eval "$(mise activate bash)"
+
+target_pane="${HERDR_ACTIVE_PANE_ID:?HERDR_ACTIVE_PANE_ID is not set}"
+base_dir="${HERDR_ACTIVE_PANE_CWD:-$PWD}"
+
+selected=$(cd "$base_dir" && fd --type f --hidden --follow --exclude .git \
+  | fzf -m --prompt="file> " --preview="bat --color=always --style=numbers --theme=ansi {}")
+[ -z "$selected" ] && exit 0
+
+text=$(printf '%s\n' "$selected" | while IFS= read -r f; do printf '%q ' "$f"; done)
+herdr pane send-text "$target_pane" "${text% }"


### PR DESCRIPTION
## Summary
- herdrにprefix+fキーバインドを追加し、fzf+batのpopupでカレントディレクトリ配下のファイルを検索して呼び出し元ペインへパスを挿入するinsert-file-path.shを実装
- deploy-herdrでconfig/herdr/scriptsを~/.config/herdr/scriptsへsymlinkするよう変更し、config.tomlのcommand参照を~/.dotfiles直下から~/.config/herdr配下に統一
- herdrのpane移動キーバインドをctrl+altからctrl+shiftへ変更、update channelを明示
- herdrが管理するSessionStartフック(herdr-agent-state.sh)をClaude Code設定に登録

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>