### PR TITLE
🐛 mtask から機能しない rlwrap ラップを削除する

### DIFF
--- a/zshrc.d/aliases.zsh
+++ b/zshrc.d/aliases.zsh
@@ -37,7 +37,7 @@ function mtask() {
     --preview="mise task info {1} 2>/dev/null")
   if [ -n "$selected" ]; then
     local task_name=$(echo "$selected" | awk '{print $1}')
-    rlwrap mise task run "$task_name"
+    mise task run "$task_name"
   fi
 }
 


### PR DESCRIPTION
## Summary
- `mtask` (fzf で mise task を選択して実行する関数) 内の `rlwrap mise task run` から `rlwrap` を除去
- mise は単一キー押下を要求する対話 UI のため rlwrap の readline 行編集が効かず、`rlwrap: warning: rlwrap appears to do nothing for mise` という警告のみが出力されていた