### PR TITLE
✨ 開発環境設定の更新(herdrキーバインド・zsh補完・Claude設定)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -127,6 +127,16 @@ function main() {
         fi
     fi
 
+    # fzf-tab requires compinit to have already run before it is loaded via sheldon
+    FPATH="$HOME/.local/share/zsh-completion/completions:$FPATH"
+    autoload bashcompinit && bashcompinit
+    autoload -Uz compinit && compinit
+    complete -C "$HOME/.local/bin/aws_completer" aws
+
+    if builtin command -v mise > /dev/null 2>&1; then
+        eval "$(mise completion zsh)"
+    fi
+
     if builtin command -v sheldon > /dev/null 2>&1; then
         eval "$(sheldon source)"
     fi
@@ -169,10 +179,6 @@ function main() {
         xhost + localhost
     fi
 
-    FPATH="$HOME/.local/share/zsh-completion/completions:$FPATH"
-    autoload bashcompinit && bashcompinit
-    autoload -Uz compinit && compinit
-    complete -C "$HOME/.local/bin/aws_completer" aws
 }
 
 if [ "$ZPROFILE_ENABLED" = true ]; then

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,21 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "advisorModel": "fable",
-  "agentPushNotifEnabled": true,
-  "alwaysThinkingEnabled": true,
-  "autoMemoryEnabled": false,
   "cleanupPeriodDays": 14,
-  "companyAnnouncements": [
-    "個人契約のClaude Codeです"
-  ],
-  "disableClaudeAiConnectors": true,
-  "editorMode": "normal",
-  "effort": "high",
-  "enabledPlugins": {
-    "aws-knowledge@nealle-managed": true,
-    "datadog@nealle-managed": true,
-    "typescript-lsp@nealle-managed": true
-  },
   "env": {
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-fable-5[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5[1m]",
@@ -24,42 +9,7 @@
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "command": "ccjanus --flexible-match",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "bash '$CLAUDE_CONFIG_DIR/hooks/herdr-agent-state.sh' session",
-            "timeout": 10,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      }
-    ]
-  },
   "includeCoAuthoredBy": true,
-  "language": "Japanese",
   "permissions": {
     "allow": [
       "Bash(./gradlew *)",
@@ -208,7 +158,6 @@
       "mcp__plugin_atlassian_atlassian__search*",
       "mcp__plugin_context7_context7__*"
     ],
-    "defaultMode": "plan",
     "deny": [
       "Bash(docker buildx build * --push)",
       "Bash(docker buildx build * --push *)",
@@ -259,15 +208,68 @@
       "Bash(git push origin -f)",
       "Bash(terraform apply *)",
       "Bash(terraform apply)"
+    ],
+    "defaultMode": "plan"
+  },
+  "model": "fable",
+  "disableClaudeAiConnectors": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccjanus --flexible-match"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_CONFIG_DIR/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '$CLAUDE_CONFIG_DIR/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
-  "showTurnDuration": true,
-  "skipAutoPermissionPrompt": true,
-  "skipWorkflowUsageWarning": true,
   "statusLine": {
+    "type": "command",
     "command": "npx -y ccstatusline@latest",
-    "padding": 0,
-    "type": "command"
+    "padding": 0
   },
-  "tui": "fullscreen"
+  "enabledPlugins": {
+    "aws-knowledge@nealle-managed": true,
+    "datadog@nealle-managed": true,
+    "typescript-lsp@nealle-managed": true,
+    "kotlin-lsp@claude-plugins-official": true
+  },
+  "language": "Japanese",
+  "alwaysThinkingEnabled": true,
+  "advisorModel": "fable",
+  "companyAnnouncements": [
+    "個人契約のClaude Codeです"
+  ],
+  "tui": "fullscreen",
+  "autoMemoryEnabled": false,
+  "skipWorkflowUsageWarning": true,
+  "editorMode": "normal",
+  "showTurnDuration": true,
+  "agentPushNotifEnabled": true,
+  "skipAutoPermissionPrompt": true,
+  "effort": "high"
 }

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -6,12 +6,8 @@ navigate_workspace_up = "k"
 navigate_workspace_down = "j"
 previous_agent = "prefix+,"
 next_agent = "prefix+."
-previous_workspace = "ctrl+shift+p"
-next_workspace = "ctrl+shift+n"
-focus_pane_left = "ctrl+shift+h"
-focus_pane_down = "ctrl+shift+j"
-focus_pane_up = "ctrl+shift+k"
-focus_pane_right = "ctrl+shift+l"
+previous_workspace = "ctrl+shift+k"
+next_workspace = "ctrl+shift+j"
 
 [[keys.command]]
 key = "prefix+u"
@@ -24,6 +20,13 @@ height = "40%"
 key = "prefix+f"
 type = "popup"
 command = "~/.config/herdr/scripts/insert-file-path.sh"
+width = "60%"
+height = "60%"
+
+[[keys.command]]
+key = "prefix+t"
+type = "popup"
+command = "~/.config/herdr/scripts/tmp-shell.sh"
 width = "60%"
 height = "60%"
 

--- a/config/herdr/scripts/tmp-shell.sh
+++ b/config/herdr/scripts/tmp-shell.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${HERDR_ACTIVE_PANE_CWD:-$HOME}"
+exec "${SHELL:-bash}"

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -2,6 +2,10 @@ shell = "zsh"
 
 [plugins]
 
+# fzf-tab は compinit の後・他の補完ウィジェットをラップするプラグイン(zsh-autosuggestions等)より前に読み込む必要がある
+[plugins.fzf-tab]
+github = "Aloxaf/fzf-tab"
+
 [plugins.zsh-autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
 #[plugins.zsh-completions]


### PR DESCRIPTION
## Summary
- herdrのキーバインドを整理: prefix不要のpane移動ショートカットを削除し、workspace切替をctrl+shift+k/jに変更、tmp-shell popup(prefix+t)を追加
- sheldonにfzf-tabプラグインを追加し、zsh補完初期化(compinit等)をsheldon読込前に移動
- Claude Code設定にkotlin-lsp pluginとmodel指定を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)