### PR TITLE
✨ herdr worktree作成時に既存worktreeを再利用できるようにする

### DIFF
--- a/config/herdr/scripts/new-worktree.sh
+++ b/config/herdr/scripts/new-worktree.sh
@@ -11,9 +11,20 @@ else
   repo="$(ghq root)/github.com/$repo_short"
 fi
 
-branch=$(gum input --placeholder "worktree branch name" --prompt "branch> ")
+worktree_list_json=$(herdr worktree list --cwd "$repo" --json)
+existing_branches=$(echo "$worktree_list_json" | jq -r '.result.worktrees[] | select(.is_linked_worktree) | .branch')
+
+branch=$({ [ -n "$existing_branches" ] && printf '%s\n' "$existing_branches"; true; } \
+  | gum filter --no-strict --placeholder "worktree branch name" --prompt "branch> ")
 [ -z "$branch" ] && exit 0
 
-worktree_json=$(herdr worktree create --cwd "$repo" --branch "$branch" --path "$repo/.claude/worktrees/$branch" --focus --json)
+existing_path=$(echo "$worktree_list_json" \
+  | jq -r --arg branch "$branch" '.result.worktrees[] | select(.branch == $branch) | .path' | head -n1)
+
+if [ -n "$existing_path" ]; then
+  worktree_json=$(herdr worktree open --cwd "$repo" --path "$existing_path" --focus --json)
+else
+  worktree_json=$(herdr worktree create --cwd "$repo" --branch "$branch" --path "$repo/.claude/worktrees/$branch" --focus --json)
+fi
 pane_id=$(echo "$worktree_json" | jq -r '.result.root_pane.pane_id')
 herdr pane run "$pane_id" "claude"


### PR DESCRIPTION
## Summary
- `prefix+u` でのworktree作成時、既にworktreeが存在するbranchを指定するとgitエラーで失敗していた問題を修正
- branch入力を`gum filter --no-strict`に変更し、既存worktreeのbranch名を候補表示しつつ新規名も入力可能に
- 既存branchが選択された場合は`herdr worktree open`で既存worktreeにアタッチ、未選択（新規名）の場合は従来通り`herdr worktree create`