### PR TITLE
🔧 ANTHROPIC_MODEL(opusplan)を削除してfableをデフォルトモデルにする

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -4,8 +4,8 @@
   "env": {
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-fable-5[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5[1m]",
-    "ANTHROPIC_MODEL": "opusplan",
     "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
+    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "includeCoAuthoredBy": true,
@@ -260,6 +260,7 @@
     "typescript-lsp@claude-plugins-official": true,
     "atlassian@claude-plugins-official": true
   },
+  "outputStyle": "Concise",
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
   "advisorModel": "fable",
@@ -273,6 +274,5 @@
   "showTurnDuration": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "effort": "high",
-  "outputStyle": "Concise"
+  "effort": "high"
 }


### PR DESCRIPTION
## Summary
- env.ANTHROPIC_MODEL="opusplan" を削除
- model:"fable" 設定との競合を解消し、fableをデフォルトモデルとして有効化